### PR TITLE
feat: ダミーイベントを非表示にする機能を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - カテゴリー別フィルタリング
 - 日付範囲指定
 - ユーザーの興味に基づくスコアリング
+- ダミーイベントの自動フィルタリング
 
 ## 技術スタック
 
@@ -19,6 +20,12 @@
 
 - `GET /health` - ヘルスチェック
 - `GET /api/events` - イベント一覧取得
+  - クエリパラメータ:
+    - `includeDemo` (optional): `true`を指定するとダミーイベントも含めて取得（デフォルト: `false`）
+    - `categories` (optional): カテゴリーフィルター（カンマ区切り）
+    - `startDate` (optional): 開始日（YYYY-MM-DD）
+    - `endDate` (optional): 終了日（YYYY-MM-DD）
+    - `limit` (optional): 取得件数（デフォルト: 50）
 - `GET /api/events/:id` - イベント詳細取得
 - `GET /api/categories` - カテゴリー一覧取得
 - `GET /api/stats` - 統計情報取得
@@ -49,7 +56,17 @@ npm run dev
 
 # スクレイピング実行
 npm run scrape
+
+# ダミーイベントのフラグ更新
+node update-demo-events.js
 ```
+
+## ダミーイベントの管理
+
+本番環境では、デフォルトでダミーイベントは表示されません。
+
+- イベントデータの`isDemo`フィールドが`true`のものがダミーイベントとして扱われます
+- `update-demo-events.js`スクリプトを実行すると、タイトルや説明にダミーキーワードが含まれるイベントに自動的に`isDemo`フラグが設定されます
 
 ## デプロイ
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,8 @@ app.get('/api/events', async (req, res) => {
       startDate,       // 開始日（YYYY-MM-DD）
       endDate,         // 終了日（YYYY-MM-DD）
       limit = 50,      // 取得件数
-      lastKey          // ページネーション用
+      lastKey,         // ページネーション用
+      includeDemo = false  // デモデータを含めるかどうか（デフォルトはfalse）
     } = req.query;
 
     // 現在日時を日本時間で取得
@@ -118,10 +119,16 @@ app.get('/api/events', async (req, res) => {
         sourceUrl: item.sourceUrl,
         imageUrl: item.imageUrl || null,
         coordinates: item.coordinates || null,
+        isDemo: item.isDemo || false,
         createdAt: item.createdAt,
         updatedAt: item.updatedAt
       });
     });
+
+    // デモデータのフィルタリング
+    if (includeDemo !== 'true') {
+      events = events.filter(event => !event.isDemo);
+    }
 
     // カテゴリーフィルタリング
     if (categories) {
@@ -217,6 +224,7 @@ app.get('/api/events/:id', async (req, res) => {
       sourceUrl: result.Item.sourceUrl,
       imageUrl: result.Item.imageUrl || null,
       coordinates: result.Item.coordinates || null,
+      isDemo: result.Item.isDemo || false,
       createdAt: result.Item.createdAt,
       updatedAt: result.Item.updatedAt
     });

--- a/src/models/Event.js
+++ b/src/models/Event.js
@@ -13,6 +13,7 @@ class Event {
     this.sourceUrl = data.sourceUrl;
     this.imageUrl = data.imageUrl || null;
     this.coordinates = data.coordinates || null; // {lat, lng}
+    this.isDemo = data.isDemo || false; // デモ/ダミーデータフラグ
     this.createdAt = data.createdAt || new Date().toISOString();
     this.updatedAt = data.updatedAt || new Date().toISOString();
   }
@@ -89,6 +90,7 @@ class Event {
           lng: { N: this.coordinates.lng.toString() }
         }
       } : { NULL: true },
+      isDemo: { BOOL: this.isDemo },
       createdAt: { S: this.createdAt },
       updatedAt: { S: this.updatedAt }
     };
@@ -112,6 +114,7 @@ class Event {
         lat: parseFloat(item.coordinates.M.lat.N),
         lng: parseFloat(item.coordinates.M.lng.N)
       } : null,
+      isDemo: item.isDemo?.BOOL || false,
       createdAt: item.createdAt.S,
       updatedAt: item.updatedAt.S
     });

--- a/update-demo-events.js
+++ b/update-demo-events.js
@@ -1,0 +1,89 @@
+// 既存のダミーイベントにisDemoフラグを設定するスクリプト
+const AWS = require('aws-sdk');
+require('dotenv').config();
+
+// AWS DynamoDB設定
+AWS.config.update({
+  region: process.env.AWS_REGION,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+});
+
+const docClient = new AWS.DynamoDB.DocumentClient();
+const tableName = process.env.DYNAMODB_TABLE_NAME;
+
+// ダミーイベントを識別するキーワード
+const demoKeywords = [
+  'サンプル',
+  'テスト',
+  'ダミー',
+  'DEMO',
+  'demo',
+  'test',
+  'sample',
+  'dummy'
+];
+
+async function updateDemoEvents() {
+  try {
+    console.log('ダミーイベントの更新を開始します...');
+    
+    // 全イベントを取得
+    const scanParams = {
+      TableName: tableName
+    };
+    
+    const result = await docClient.scan(scanParams).promise();
+    console.log(`総イベント数: ${result.Items.length}`);
+    
+    let updatedCount = 0;
+    let demoCount = 0;
+    
+    for (const item of result.Items) {
+      // タイトルまたは説明にダミーキーワードが含まれているか確認
+      const isDemo = demoKeywords.some(keyword => 
+        (item.title && item.title.includes(keyword)) ||
+        (item.description && item.description.includes(keyword))
+      );
+      
+      if (isDemo) {
+        demoCount++;
+        console.log(`ダミーイベント検出: ${item.title}`);
+        
+        // isDemoフラグを設定
+        const updateParams = {
+          TableName: tableName,
+          Key: {
+            id: item.id
+          },
+          UpdateExpression: 'SET isDemo = :isDemo',
+          ExpressionAttributeValues: {
+            ':isDemo': true
+          }
+        };
+        
+        await docClient.update(updateParams).promise();
+        updatedCount++;
+        console.log(`✓ 更新完了: ${item.title}`);
+      }
+    }
+    
+    console.log(`\n=== 更新完了 ===`);
+    console.log(`ダミーイベント数: ${demoCount}`);
+    console.log(`更新したイベント数: ${updatedCount}`);
+    console.log(`実データイベント数: ${result.Items.length - demoCount}`);
+    
+  } catch (error) {
+    console.error('エラーが発生しました:', error);
+    process.exit(1);
+  }
+}
+
+// 実行確認
+console.log('このスクリプトは既存のイベントをスキャンし、ダミーイベントにisDemoフラグを設定します。');
+console.log('続行しますか？ (Ctrl+Cでキャンセル)');
+
+// 3秒待機
+setTimeout(() => {
+  updateDemoEvents();
+}, 3000);


### PR DESCRIPTION
## 概要
ユーザーの混乱を避けるため、ダミーイベントを非表示にする機能を実装しました。

## 変更内容

### 1. Eventモデルの拡張
- `isDemo`フィールドを追加（デフォルト値: `false`）
- DynamoDBの保存/読み込み処理にも対応

### 2. APIエンドポイントの改善
- `/api/events`エンドポイントでデフォルトでダミーイベントを除外
- `includeDemo=true`クエリパラメータを指定した場合のみダミーイベントを含める
- `/api/events/:id`エンドポイントでも`isDemo`フィールドに対応

### 3. データ更新スクリプト
- `update-demo-events.js`スクリプトを追加
- 既存のイベントをスキャンし、タイトルや説明にダミーキーワードが含まれるものに`isDemo`フラグを設定
- ダミーキーワード: サンプル、テスト、ダミー、DEMO、demo、test、sample、dummy

## 使用方法

1. 既存のダミーイベントを更新：
```bash
node update-demo-events.js
```

2. APIでの確認：
```bash
# ダミーイベントを除外（デフォルト）
GET /api/events

# ダミーイベントを含める
GET /api/events?includeDemo=true
```

## テスト
- ローカル環境でダミーイベントのフィルタリングが正常に動作することを確認してください
- `update-demo-events.js`スクリプトを実行し、既存のダミーイベントが正しく識別されることを確認してください

## 次のステップ
この後、エリア対応（西小山・武蔵小山）の実装を行います。